### PR TITLE
Roll-forward: Add hook on file_share and send to ootp bot server.

### DIFF
--- a/src/bin/slackApi.ts
+++ b/src/bin/slackApi.ts
@@ -1,4 +1,5 @@
 import type { GenericMessageEvent } from '@slack/bolt';
+import { subtype } from '@slack/bolt';
 import axios from 'axios';
 import config from 'config';
 import type { AIClient } from '../clients/ai/AIClient.js';
@@ -93,11 +94,44 @@ async function sendOotpChat(messages, channel, say) {
         type: channel,
       }));
       break;
+    case '':
+      // Intentional no response.
+      break;
     default:
       console.error('unknown action:', data.kind);
       break;
   }
 }
+
+app.message(subtype('file_share'), async ({ event, message, say }) => {
+  if (message.subtype !== 'file_share' || event.subtype !== 'file_share') {
+    return;
+  }
+  if (event.channel === channelMap.ootpHighlights) {
+    for (const file of message.files) {
+      const response = await axios.get(file.url_private, {
+        responseType: 'arraybuffer',
+        headers: {'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`}
+      });
+      if (response.status == 200) {
+        const messages = [{
+          user: message.user,
+          text: message.text,
+          file: {
+            mimetype: file.mimetype,
+            data: Buffer.from(response.data).toString('base64')
+          }
+        }];
+        await sendOotpChat(messages, event.channel, (text) =>
+          say({
+            text,
+            thread_ts: event.thread_ts || event.ts,
+          })
+        )
+      }
+    }
+  }
+});
 
 app.event('app_mention', async ({ event, say }) => {
   console.log(


### PR DESCRIPTION
Roll-forward of d8b61bf4d7ae2da929604c474db5662e3e66e18f, fixing the typescript errors.

At the moment, the server will look for images that are trades and respond with nicely-formatted links to the players on the website.