### PR TITLE
Post a summary of the results to slack after each file upload.

### DIFF
--- a/src/bin/ootpFileManager.ts
+++ b/src/bin/ootpFileManager.ts
@@ -90,7 +90,7 @@ async function postSummary(client, lastMessage) {
     const result = await client.conversations.history({
       channel: channelMap.ootpLog,
       oldest: lastMessage,
-      latest: Date.now,
+      latest: Date.now(),
       limit: 200,
       cursor: cursor
     });

--- a/src/clients/slack.ts
+++ b/src/clients/slack.ts
@@ -1,6 +1,6 @@
 import bolt from '@slack/bolt';
-const App = bolt.App;
 import config from 'config';
+const App = bolt.App;
 
 export const app = new App({
   token: config.get('slack.token'),
@@ -15,6 +15,7 @@ export const app = new App({
 export const channelMap = {
   cabin: 'C6BB7U95Z',
   ootpHighlights: 'C04J9TWRNJ3',
+  ootpLog: 'C04K33NVCC9',
   politics: 'CPXA5CBHP',
   specialist: 'C6APJ5KG8',
   sports: 'C6ATH6LBB',


### PR DESCRIPTION
This collects all messages to the #oberfähnrich_ootp_finals channel since the last file upload, sends them to the /summary endpoint on ootp.bedaire.com to get a summary, and then posts the summary to #officer_cadet_ootp_highlights.